### PR TITLE
fix(FEC-13131): Download plugin - Accessibility - After pressing Enter on the download icon, the focus stays on the download button

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier:fix": "prettier --write ."
   },
   "dependencies": {
-    "@playkit-js/common": "1.1.5",
+    "@playkit-js/common": "1.2.2",
     "@playkit-js/ui-managers": "1.3.5",
     "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js#d0a53aaab67289a4a4296f0cf143821e874d58d4"
   },

--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -106,6 +106,7 @@ const DownloadOverlay = withText({
                 <div className={`${styles.iconContainer} ${styles.downloadIcon}`}>
                   <div>
                     <Button
+                      focusOnMount={true}
                       type={ButtonType.borderless}
                       size={ButtonSize.medium}
                       disabled={false}

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,16 +481,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playkit-js/common@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.1.5.tgz#20410ef8e32c4820146a2a462d5318fac6be1e96"
-  integrity sha512-NgVELo6z9+DI9aiKL8oj5p/d5pzJCZgwuk0LN3lKizPuNfvu/30lavsH4hNCrWOjgnT7o4EEFrmVK9buzqmIHQ==
-  dependencies:
-    "@playkit-js/playkit-js-ui" "^0.74.0"
-    classnames "^2.3.2"
-    linkify-it "^4.0.1"
-
-"@playkit-js/common@^1.1.3":
+"@playkit-js/common@1.2.2", "@playkit-js/common@^1.1.3":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.2.2.tgz#29c9a3cdeac27ec76c8e38a32c89f8dc0811d9ed"
   integrity sha512-hGAnBRJd+mu5InXNCm5XUozUdLAUzkBQOEo1kOsGlhB2cv6nrICJU0ZXaJQICG/aChxg2I8UFfd2Zq2W8yyzIA==


### PR DESCRIPTION
### Description of the Changes

Focus on download file button when download overlay is displayed.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
