### PR TITLE
fix(FEC-13171): The download plugin icon in the top bar of the player is not behaving like in the guidelines

### DIFF
--- a/src/components/download-overlay-button/download-overlay-button.tsx
+++ b/src/components/download-overlay-button/download-overlay-button.tsx
@@ -16,7 +16,7 @@ const DownloadOverlayButton = withText({
   return (
     <div>
       <Tooltip label={downloadLabel}>
-        <button aria-label={downloadLabel} tabIndex={0} className={`${KalturaPlayer.ui.style.controlButton}`} onClick={onClick}>
+        <button aria-label={downloadLabel} tabIndex={0} className={`${KalturaPlayer.ui.style.upperBarIcon}`} onClick={onClick}>
           <Icon id={`download-overlay-icon`} path={DOWNLOAD} viewBox={`0 0 32 32`} />
         </button>
       </Tooltip>


### PR DESCRIPTION
### Description of the Changes

Update class of overlay toggle button
Resolves FEC-13171

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
