### PR TITLE
fix(FEC-13182): Player v7 | Download plugin | The name of the Download plugin in the v7 player is "Downloads"

### DIFF
--- a/src/components/download-overlay-button/download-overlay-button.tsx
+++ b/src/components/download-overlay-button/download-overlay-button.tsx
@@ -11,7 +11,7 @@ const {Icon, Tooltip} = KalturaPlayer.ui.components;
  * @param {string} props.downloadLabel Button label.
  */
 const DownloadOverlayButton = withText({
-  downloadLabel: 'download.downloads'
+  downloadLabel: 'download.download'
 })(({onClick, downloadLabel}: {onClick: () => void; downloadLabel: string}) => {
   return (
     <div>


### PR DESCRIPTION
### Description of the Changes

Update Download overlay button tooltip
Resolves FEC-13182

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
