### PR TITLE
[WEB][Download] V7 downloading plug in isnt working on IOS 16.5 version

### DIFF
--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -82,7 +82,6 @@ class DownloadService {
     aElement.href = downloadUrl;
     aElement.hidden = true;
     aElement.download = fileName;
-    aElement.target = '_blank';
     aElement.rel = 'noopener noreferrer';
     aElement.click();
   }


### PR DESCRIPTION
### Description of the Changes

Remove target attribute to check if it breaks download logic on iOS

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
