### PR TITLE
fix(SUP-38095):add Spanish's translation for downloads plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ First, clone and run [yarn] to install dependencies:
 [yarn]: https://yarnpkg.com/lang/en/
 
 ```
-git clone https://github.com/kaltura/playkit-js-download.git
-cd playkit-js-download
+git clone https://github.com/kaltura/playkit-js-downloads.git
+cd playkit-js-downloads
 yarn install
 ```
 
@@ -62,7 +62,7 @@ Finally, add the bundle as a script tag in your page, and initialize the player
 <!--Playkit ui managers plugin -->
 <script type="text/javascript" src="/PATH/TO/FILE/playkit-ui-manager.js"></script>
 <!--PlayKit download plugin-->
-<script type="text/javascript" src="/PATH/TO/FILE/playkit-download.js"></script>
+<script type="text/javascript" src="/PATH/TO/FILE/playkit-downloads.js"></script>
 <div id="player-placeholder" style="height:360px; width:640px">
   <script type="text/javascript">
     var playerContainer = document.querySelector("#player-placeholder");

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -8,7 +8,7 @@ import {DownloadPluginManager} from 'download-plugin-manager';
 
 import {ContribServices} from '@playkit-js/common/dist/ui-common/contrib-services';
 import {OnClickEvent, ToastSeverity} from '@playkit-js/common';
-import {ui} from "@playkit-js/kaltura-player-js";
+import {ui} from '@playkit-js/kaltura-player-js';
 const {Text} = ui.preacti18n;
 const PRESETS = ['Playback'];
 

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -74,8 +74,7 @@ class Download extends KalturaPlayer.core.BasePlugin {
 
   private injectOverlayComponents() {
     this.iconId = this.upperBarManager.add({
-      //@ts-ignore
-      label: <Text id="download.download">Download</Text>,
+      label: <Text id="download.download">Download</Text> as any,
       svgIcon: {
         viewBox: '0 0 32 32',
         path: DOWNLOAD

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -74,7 +74,7 @@ class Download extends KalturaPlayer.core.BasePlugin {
 
   private injectOverlayComponents() {
     this.iconId = this.upperBarManager.add({
-      label: <Text id="download.download">Download</Text> as any,
+      label: (<Text id="download.download">Download</Text>) as never,
       svgIcon: {
         viewBox: '0 0 32 32',
         path: DOWNLOAD

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -8,7 +8,8 @@ import {DownloadPluginManager} from 'download-plugin-manager';
 
 import {ContribServices} from '@playkit-js/common/dist/ui-common/contrib-services';
 import {OnClickEvent, ToastSeverity} from '@playkit-js/common';
-
+import {ui} from "@playkit-js/kaltura-player-js";
+const {Text} = ui.preacti18n;
 const PRESETS = ['Playback'];
 
 class Download extends KalturaPlayer.core.BasePlugin {
@@ -73,7 +74,8 @@ class Download extends KalturaPlayer.core.BasePlugin {
 
   private injectOverlayComponents() {
     this.iconId = this.upperBarManager.add({
-      label: 'Download',
+      //@ts-ignore
+      label: <Text id="download.download">Download</Text>,
       svgIcon: {
         viewBox: '0 0 32 32',
         path: DOWNLOAD


### PR DESCRIPTION
issue:
when plugin added to more plugin the label didnt translated

solution:
add option to translate the label
