### PR TITLE
fix(SUP-38493) Close button is read as "unlabeled zero button"

### DIFF
--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -157,6 +157,7 @@ const DownloadOverlay = withText({
                     type={ButtonType.borderless}
                     size={ButtonSize.medium}
                     tooltip={{label: closeLabel!}}
+                    ariaLabel={closeLabel}
                     icon={'close'}
                     setRef={ref => {
                       closeButtonRef.current = ref;


### PR DESCRIPTION
### Description of the Changes

**issue:**
screen reader read the close button as "unlabeled zero button"

**solution:**
added aria-label: "close"

solves [SUP-38493](https://kaltura.atlassian.net/browse/SUP-38493)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
