### PR TITLE
fix(FEC-13295) Download plugin - Accessibility - Need to change the download button lable in the download overlay

### DIFF
--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -22,6 +22,7 @@ interface DownloadOverlayProps {
   downloadStartedLabel?: string;
   downloadFailedLabel?: string;
   closeLabel?: string;
+  downloadButtonLabel?: string;
   setFocus: () => void;
 }
 
@@ -61,7 +62,8 @@ const DownloadOverlay = withText({
   downloadsLabel: 'download.downloads',
   downloadStartedLabel: 'download.download_has_started',
   downloadFailedLabel: 'download.download_has_failed',
-  closeLabel: 'overlay.close'
+  closeLabel: 'overlay.close',
+  downloadButtonLabel: 'download.download_button_label'
 })(
   connect(mapStateToProps)(
     withEventManager(
@@ -74,6 +76,7 @@ const DownloadOverlay = withText({
         downloadStartedLabel,
         downloadFailedLabel,
         closeLabel,
+        downloadButtonLabel,
         setFocus
       }: DownloadOverlayProps) => {
         const [isVisible, setIsVisible] = useState(false);
@@ -125,6 +128,7 @@ const DownloadOverlay = withText({
                     data-testid="download-overlay-download-button"
                     className={`${styles.fileInfo} ${sizeClass}`}
                     tabIndex={0}
+                    aria-label={downloadButtonLabel}
                     ref={downloadRef}
                     onBlur={() => {
                       if (isVisible) {

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -5,7 +5,8 @@
       "downloads": "Downloads",
       "download_has_started": "Download has started",
       "download_has_failed": "Download has failed",
-      "attachments": "Attachments"
+      "attachments": "Attachments",
+      "download_button_label": "Click to download the video"
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

screen reader reads the file name in the download button, 
change it to “Click to download the video”

solves [FEC-13295](https://kaltura.atlassian.net/browse/FEC-13295)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13295]: https://kaltura.atlassian.net/browse/FEC-13295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ