### PR TITLE
feat: support image download

### DIFF
--- a/cypress/e2e/downloads.cy.ts
+++ b/cypress/e2e/downloads.cy.ts
@@ -96,7 +96,7 @@ describe('download plugin', () => {
           expect(requestCount).to.equal(0);
         });
     });
-    it('should be blocked for image entry', () => {
+    it.skip('should be blocked for image entry', () => {
       return loadPlayer()
         .then(() => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@playkit-js/common": "^1.2.11",
     "@playkit-js/kaltura-player-js": "3.17.0-canary.0-634f42e",
-    "@playkit-js/ui-managers": "^1.3.11",
+    "@playkit-js/ui-managers": "1.4.0-canary.0-96ebad5",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",
     "conventional-github-releaser": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@playkit-js/common": "^1.2.11",
-    "@playkit-js/kaltura-player-js": "3.14.4",
+    "@playkit-js/kaltura-player-js": "3.17.0-canary.0-634f42e",
     "@playkit-js/ui-managers": "^1.3.11",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "kaltura": {
     "name": "downloads",
     "dependencies": {
-      "playkit-ui-managers": "1.3.14"
+      "playkit-ui-managers": "1.4.0-canary.0-96ebad5"
     }
   },
   "publishConfig": {

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -10,7 +10,7 @@ import {ContribServices} from '@playkit-js/common/dist/ui-common/contrib-service
 import {OnClickEvent, ToastSeverity} from '@playkit-js/common';
 import {ui} from '@playkit-js/kaltura-player-js';
 const {Text} = ui.preacti18n;
-const PRESETS = ['Playback'];
+const PRESETS = ['Playback', 'Img'];
 
 class Download extends KalturaPlayer.core.BasePlugin {
   static defaultConfig: DownloadConfig = {
@@ -63,7 +63,11 @@ class Download extends KalturaPlayer.core.BasePlugin {
 
   private _handleClick = (event: OnClickEvent, byKeyboard: boolean) => {
     this.triggeredByKeyboard = byKeyboard;
-    this.downloadPluginManager.showOverlay = !this.downloadPluginManager.showOverlay;
+    if (this.player.isImage()) {
+      this.downloadPluginManager.downloadFile();
+    } else {
+      this.downloadPluginManager.showOverlay = !this.downloadPluginManager.showOverlay;
+    }
   };
 
   private _focusPluginButton = () => {

--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -9,7 +9,7 @@ class DownloadService {
   }
 
   private isEntrySupported() {
-    return !(this.player.isLive() || this.player.getVideoElement().mediaKeys || this.player.isImage());
+    return !(this.player.isLive() || this.player.getVideoElement().mediaKeys);
   }
 
   private isContentTypeSupported(response: Response) {
@@ -54,6 +54,15 @@ class DownloadService {
   async getDownloadMetadata(config: DownloadConfig): Promise<DownloadMetadata> {
     if (!(this.isPlatformSupported() && this.isEntrySupported())) {
       return null;
+    }
+
+    if (this.player.isImage()) {
+      const url = this.player.sources.downloadUrl;
+      if (!url) return null;
+      return {
+        downloadUrl: url,
+        fileName: this.player.sources?.metadata?.name || 'Image'
+      };
     }
 
     const requestUrl = this.getDownloadUrl(config);

--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -12,10 +12,10 @@ class DownloadService {
     return !(this.player.isLive() || this.player.getVideoElement().mediaKeys);
   }
 
-  private isContentTypeSupported(response: Response) {
+  private isContentTypeSupported(response: Response, typeToCheck = 'video') {
     if (response.ok) {
       const contentType = response.headers.get('content-type');
-      return !!(contentType && contentType.toLowerCase().includes('video'));
+      return !!(contentType && contentType.toLowerCase().includes(typeToCheck));
     }
     return false;
   }
@@ -56,16 +56,7 @@ class DownloadService {
       return null;
     }
 
-    if (this.player.isImage()) {
-      const url = this.player.sources.downloadUrl;
-      if (!url) return null;
-      return {
-        downloadUrl: url,
-        fileName: this.player.sources?.metadata?.name || 'Image'
-      };
-    }
-
-    const requestUrl = this.getDownloadUrl(config);
+    const requestUrl = this.player.isImage() && this.player.sources.downloadUrl ? this.player.sources.downloadUrl : this.getDownloadUrl(config);
     if (!requestUrl) {
       return null;
     }
@@ -78,8 +69,8 @@ class DownloadService {
 
       const downloadUrl = response.url;
 
-      const isContentTypeSupported = this.isContentTypeSupported(response);
-      const fileName = this.getFilename(response);
+      const isContentTypeSupported = this.isContentTypeSupported(response, this.player.isImage() ? 'image' : 'video');
+      const fileName = this.player.isImage() ? this.player.sources?.metadata?.name || 'Image' : this.getFilename(response);
 
       if (isContentTypeSupported && fileName) {
         return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,10 +550,10 @@
     js-logger "^1.6.0"
     ua-parser-js "1.0.2"
 
-"@playkit-js/ui-managers@^1.3.11":
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/@playkit-js/ui-managers/-/ui-managers-1.3.11.tgz#3b3531a699ffa8d2cb1f4702e514ab7686553c98"
-  integrity sha512-t+NOfm8LDo0IhLX90Wbmod6FP+xavzKk9JSNZ3ByJvAg0NpnVeuvdD1sPPorRsf7LQu9cbMWvz6T+Z+F7BnSNQ==
+"@playkit-js/ui-managers@1.4.0-canary.0-96ebad5":
+  version "1.4.0-canary.0-96ebad5"
+  resolved "https://registry.yarnpkg.com/@playkit-js/ui-managers/-/ui-managers-1.4.0-canary.0-96ebad5.tgz#4a5c3233253644091b0c09808d46c7484c5bad8b"
+  integrity sha512-k+EgDa0QPF+fGuqsj+h7w6bJCaNNZOdoJEc4XbM6JyF0RawH9dE2RBUqBjwo8dUWBtjpoIxamcJVTs5h7yMTrg==
   dependencies:
     "@playkit-js/common" "^1.2.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,39 +490,49 @@
     classnames "^2.3.2"
     linkify-it "^4.0.1"
 
-"@playkit-js/kaltura-player-js@3.14.4":
-  version "3.14.4"
-  resolved "https://registry.yarnpkg.com/@playkit-js/kaltura-player-js/-/kaltura-player-js-3.14.4.tgz#6bc7d16a958e531c9c36368d95b525bac34abced"
-  integrity sha512-N5FYvVvRvAGtFMnHYtagOrskOoR/mPtqj8VEpGf3s+5tHw1lAQt/bNfKSXrOUyFwwprvzZgv/VC9sPjRHSjyIA==
+"@playkit-js/kaltura-player-js@3.17.0-canary.0-634f42e":
+  version "3.17.0-canary.0-634f42e"
+  resolved "https://registry.yarnpkg.com/@playkit-js/kaltura-player-js/-/kaltura-player-js-3.17.0-canary.0-634f42e.tgz#c273243eab632c864bd1778371d009b48613bdd8"
+  integrity sha512-rjM63IyI5aVlzqId1F4UCWtaYCdVRcs7k8KluFOAI/CIVaFslpHts3EpaDCUAJEWmjA1Mdhl6yaUUZ/awtQ0Ug==
   dependencies:
     "@babel/polyfill" "^7.0.0"
-    "@playkit-js/playkit-js" "0.82.3"
-    "@playkit-js/playkit-js-dash" "1.34.2"
-    "@playkit-js/playkit-js-hls" "1.32.4"
-    "@playkit-js/playkit-js-providers" "2.39.3"
-    "@playkit-js/playkit-js-ui" "0.77.2"
+    "@playkit-js/playkit-js" "0.84.0-canary.0-b0adedc"
+    "@playkit-js/playkit-js-dash" "1.35.1-canary.0-24c5f50"
+    "@playkit-js/playkit-js-hls" "1.33.0-canary.0-3bc79e3"
+    "@playkit-js/playkit-js-providers" "2.40.0-canary.0-8ec30df"
+    "@playkit-js/playkit-js-ui" "0.78.0-canary.0-4abfdb2"
     "@types/preact-i18n" "^2.3.1"
-    hls.js "1.3.5"
+    hls.js "1.4.11"
     intersection-observer "^0.12.0"
     proxy-polyfill "^0.3.0"
-    shaka-player "4.3.5"
+    shaka-player "4.4.2"
 
-"@playkit-js/playkit-js-dash@1.34.2":
-  version "1.34.2"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-dash/-/playkit-js-dash-1.34.2.tgz#e99308387866400413dab0f57368423ddd6f32ee"
-  integrity sha512-cmQ7bg3RecUiRapASZ/kZJiNAv7lECymTptH4zjt9UYp5l4I4yA7sF0tNSdZ8GXVWFEajS4pqnogaYDwHx26lw==
+"@playkit-js/playkit-js-dash@1.35.1-canary.0-24c5f50":
+  version "1.35.1-canary.0-24c5f50"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-dash/-/playkit-js-dash-1.35.1-canary.0-24c5f50.tgz#568047fcb99b07e9c4230c7ab2baac42a22f94c2"
+  integrity sha512-dYE+URMt1sJjXQJvjfRqMO04YyspW9FBbA8tBsGXd9QhQu0Mdo79j4chIu0uo5fptLqQ6McpWIM4gVC1P2Nkrw==
 
-"@playkit-js/playkit-js-hls@1.32.4":
-  version "1.32.4"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.32.4.tgz#bf2f690e273737feb6f51cb8fee912d36fba9570"
-  integrity sha512-4ZZesmnIinEN9ONtjR0qz+lRUO9k/et6BTfeGHseCCb3qGPS6ngTtZMhlLqPXESFq7KwwK7B9gVL87cid5p0/Q==
+"@playkit-js/playkit-js-hls@1.33.0-canary.0-3bc79e3":
+  version "1.33.0-canary.0-3bc79e3"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.33.0-canary.0-3bc79e3.tgz#6ca088084d970b461d2bc6fa3790afb6f76f1048"
+  integrity sha512-ZNKJlSK2hZ+p2UGuXurBQxssqnygoPeWZh/a5Lxj0dkVMm0z0WpF3LPcfUvdrR2zJhKrFvAxRP+mrGK8puEGEw==
 
-"@playkit-js/playkit-js-providers@2.39.3":
-  version "2.39.3"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.39.3.tgz#f7d7c71139420eaf3311b8b16e9b3e83fee0855c"
-  integrity sha512-g6uj3beu5tsvvUwCAjteDRT8mHiA1yAQQ8vplHg8x9waa4IIahQWX0qFtFW9K97PYVg9juj0m4ZGfTex8wZZKw==
+"@playkit-js/playkit-js-providers@2.40.0-canary.0-8ec30df":
+  version "2.40.0-canary.0-8ec30df"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.40.0-canary.0-8ec30df.tgz#9656a3bb601fcdc2955d985fae920c5efc61590c"
+  integrity sha512-8RvTmN3NTlyQ09ut7FkrQCU/Lu5FuL77Vf4iEdsuH31Klnwdihmlv9HQbpxSA+JqeBFQx0NiA+sjxkmhWYZofw==
 
-"@playkit-js/playkit-js-ui@0.77.2", "@playkit-js/playkit-js-ui@^0.77.1":
+"@playkit-js/playkit-js-ui@0.78.0-canary.0-4abfdb2":
+  version "0.78.0-canary.0-4abfdb2"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-ui/-/playkit-js-ui-0.78.0-canary.0-4abfdb2.tgz#7f628d4c5e52ade68815abb4e6c1f03edcc4b69d"
+  integrity sha512-ZT8tu3jQ+8OR/F/2+lsBCDEJ66itjp2tX65VFNtiC/3chxMgctyJa5BLuCMrgpElpDZieRs+t4hYuRZbr+RUJQ==
+  dependencies:
+    preact "^10.3.4"
+    preact-i18n "^2.0.0-preactx.2"
+    react-redux "^7.2.0"
+    redux "^4.0.5"
+
+"@playkit-js/playkit-js-ui@^0.77.1":
   version "0.77.2"
   resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-ui/-/playkit-js-ui-0.77.2.tgz#5340ba529a0a0554c4a63d7720a0bf8b27c7a696"
   integrity sha512-vuRHXlde6P7I0YdXchkcdfSQVw1sn1MCHx0o9g4AakwlCawZ9JktIWGD2s4hTCRnH5HAk6xJbMMMRaEgjCg9bQ==
@@ -532,10 +542,10 @@
     react-redux "^7.2.0"
     redux "^4.0.5"
 
-"@playkit-js/playkit-js@0.82.3":
-  version "0.82.3"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.82.3.tgz#2ff58c11be79b5cab6d1285dad00f7ab24e68748"
-  integrity sha512-JAuU5xTUeb+7dotDYhjBDoT1MsdnqOjYW2i4/bjYyW2qU8QQyd6/UgHLfTCczP+XHEO4sZ9S5Nh7I6s+IZTEuw==
+"@playkit-js/playkit-js@0.84.0-canary.0-b0adedc":
+  version "0.84.0-canary.0-b0adedc"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.0-canary.0-b0adedc.tgz#b3de4a000e68b6ac964315b830254fcecf6f0eba"
+  integrity sha512-2SyZN/WmbLqVMuEGtmpxlmRDgR5bPujJL/2TtKuFbndAR4Kl0d6+7ABNme8T33Aixup/nQ9psUTqSEhRNR1Gig==
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "1.0.2"
@@ -3371,10 +3381,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hls.js@1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.3.5.tgz#0e8b0799ecf2feb7ba199f5e95f35ba9552e04f4"
-  integrity sha512-uybAvKS6uDe0MnWNEPnO0krWVr+8m2R0hJ/viql8H3MVK+itq8gGQuIYoFHL3rECkIpNH98Lw8YuuWMKZxp3Ew==
+hls.js@1.4.11:
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.4.11.tgz#6ca2d7ab56f2725f27bb5f2e3c7982c6ec287118"
+  integrity sha512-rhPSUMACcIBbcUnwWnIcRgGXqJJt0xBRxvhzl99XpGHtnnLKjbczmmBmUuQueAQcbL3SdN7D5peAObR18VrhvQ==
 
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -5518,10 +5528,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shaka-player@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.3.5.tgz#304d60ad867fb7a0780b850b32a9614296b842db"
-  integrity sha512-WkqvHm8QHOsQ71d/qoc2Wa6Z5rBrG3Zgsc6ho9I9e8Xwa0io+MeREgqBuG0z6qoXK55sTImipFhDoERrkmDdUg==
+shaka-player@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.4.2.tgz#df5e49a698d6bb85e0c9bf7d729563d31a79ff24"
+  integrity sha512-sDw4wmRIw920f/JzA4XHGzEBq/ywYqgeEeSbUJIgJS8xNPcwWbaUuXJXFbPAVMLJoj9co2PrX20qTWTUSpDADg==
   dependencies:
     eme-encryption-scheme-polyfill "^2.1.1"
 


### PR DESCRIPTION
### Description of the Changes

add support for downloading image.
if the player is image player then the expected behavior is that once clicking on the download, the image file will be directly downloaded and the overlay will not show.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
