### PR TITLE
feat: add fallback to image download

### DIFF
--- a/src/download-plugin-manager.tsx
+++ b/src/download-plugin-manager.tsx
@@ -14,7 +14,7 @@ class DownloadPluginManager extends KalturaPlayer.core.FakeEventTarget {
 
   constructor(private downloadPlugin: Download) {
     super();
-    this.downloadService = new DownloadService(downloadPlugin.player);
+    this.downloadService = new DownloadService(downloadPlugin.player, downloadPlugin.logger);
   }
 
   async getDownloadMetadata(refresh = false): Promise<DownloadMetadata> {

--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -1,7 +1,7 @@
 import {DownloadConfig, DownloadMetadata} from '../types';
 
 class DownloadService {
-  constructor(private player: KalturaPlayerTypes.Player) {}
+  constructor(private player: KalturaPlayerTypes.Player, private logger: KalturaPlayerTypes.Logger) {}
 
   private isPlatformSupported() {
     const userAgent = navigator.userAgent || '';
@@ -82,6 +82,7 @@ class DownloadService {
         };
       }
     } catch (e: any) {
+      this.logger.warn('Failed to get file from url: ', requestUrl);
       // in case HEAD request failed for raw service (image use-case), retry to get the image download metadata using thumbnail service
       if (this.player.isImage()) {
         return await this.getImageDownloadMetadata();
@@ -109,7 +110,9 @@ class DownloadService {
         downloadUrl: href,
         fileName: this.player.sources?.metadata?.name || 'image'
       };
-    } catch (e: any) {}
+    } catch (e: any) {
+      this.logger.warn('Failed to get image from url: ', requestUrl);
+    }
     return null;
   }
 

--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -97,7 +97,7 @@ class DownloadService {
     const imageSource = this.player.config.sources.image;
     let requestUrl = imageSource && imageSource.length > 0 ? imageSource[0].url : '';
     if (!requestUrl) return null;
-    if (!requestUrl.includes('ks')) {
+    if (!requestUrl.includes('/ks/')) {
       const ks = this.player.config.session.ks;
       requestUrl = ks ? `${requestUrl}/ks/${ks}` : requestUrl;
     }


### PR DESCRIPTION
### Description of the Changes

in case of an image player, there is a possibility that the HEAD request with `raw` service will fail.
the solution is to add a fallback option by trying to get the image from the image source, that is using the thumbnail service.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
