### PR TITLE
fix(FEC-13452): download not working for image if no attachments

### DIFF
--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -36,12 +36,15 @@ class DownloadService {
     const assets = await this.getKalturaAssets();
     Object.assign(metadata, assets);
     metadata!.imageDownloadUrl = await this.handleImageDownload();
-    const downloadUrls: Map<string, string> = await this.getDownloadUrls(metadata);
 
-    // assign the download urls to the assets by id
-    metadata.flavors = this.setDownloadUrls(metadata?.flavors, downloadUrls);
-    metadata.captions = this.setDownloadUrls(metadata?.captions, downloadUrls);
-    metadata.attachments = this.setDownloadUrls(metadata?.attachments, downloadUrls);
+    if (metadata?.flavors.length || metadata?.captions.length || metadata?.attachments.length) {
+      const downloadUrls: Map<string, string> = await this.getDownloadUrls(metadata);
+
+      // assign the download urls to the assets by id
+      metadata.flavors = this.setDownloadUrls(metadata?.flavors, downloadUrls);
+      metadata.captions = this.setDownloadUrls(metadata?.captions, downloadUrls);
+      metadata.attachments = this.setDownloadUrls(metadata?.attachments, downloadUrls);
+    }
 
     metadata!.fileName = this.getFilename(metadata);
     return metadata;


### PR DESCRIPTION
### Description of the Changes

**the issue:**
in image entry case, there are no flavors and no captions, but there might be attachments. in case there are no attachments as well, the request to BE to get the downloadUrls is failing; therefore, the download icon is absent.

**solution:**
make the multiRequest to get the download urls, only if at least 1 of the arrays (flavors/captions/attachments) is not empty.

Solves FEC-13452

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
