### PR TITLE
fix(FEC-13455): download is failing for youtube entries

### DIFF
--- a/src/components/sources-list/sources-list.tsx
+++ b/src/components/sources-list/sources-list.tsx
@@ -142,13 +142,19 @@ export const SourcesList = withText({
       return _renderFlavor(defaultFlavor!);
     };
 
+    const _renderSources = () => {
+      if (imageUrl) {
+        return _renderDownloadItem('1', fileName, '', imageUrl, _getImageIcon(), true);
+      } else if (flavors.length > 0) {
+        return _renderExpandableFlavors();
+      } else {
+        return undefined;
+      }
+    };
+
     return (
       <div className={styles.sourcesContainer} data-testid={'download-overlay-sources-container'}>
-        {imageUrl
-          ? _renderDownloadItem('1', fileName, '', imageUrl, _getImageIcon(), true)
-          : flavors.length > 0
-          ? _renderExpandableFlavors()
-          : undefined}
+        {_renderSources()}
       </div>
     );
   }

--- a/src/components/sources-list/sources-list.tsx
+++ b/src/components/sources-list/sources-list.tsx
@@ -144,7 +144,11 @@ export const SourcesList = withText({
 
     return (
       <div className={styles.sourcesContainer} data-testid={'download-overlay-sources-container'}>
-        {flavors.length > 0 ? _renderExpandableFlavors() : _renderDownloadItem('1', fileName, '', imageUrl, _getImageIcon(), true)}
+        {imageUrl
+          ? _renderDownloadItem('1', fileName, '', imageUrl, _getImageIcon(), true)
+          : flavors.length > 0
+          ? _renderExpandableFlavors()
+          : undefined}
       </div>
     );
   }

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -111,18 +111,8 @@ class Download extends KalturaPlayer.core.BasePlugin {
   private shouldInjectUI(downloadMetadata: DownloadMetadata): boolean {
     if (!downloadMetadata) return false;
     const {flavors, captions, attachments, imageDownloadUrl} = downloadMetadata;
-    if (flavors.length || imageDownloadUrl) {
-      return true;
-    }
-    // getting here means that there are no flavors and there is no image (for example, a youtube entry with captions)
     const {displayCaptions, displayAttachments} = this.downloadPluginManager.downloadPlugin.config;
-    if (captions.length && !attachments.length && !displayCaptions) {
-      return false;
-    }
-    if (attachments.length && !captions.length && !displayAttachments) {
-      return false;
-    }
-    return true;
+    return flavors.length || imageDownloadUrl || (captions.length && displayCaptions) || (attachments.length && displayAttachments);
   }
 
   async loadMedia() {

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -108,13 +108,30 @@ class Download extends KalturaPlayer.core.BasePlugin {
     );
   }
 
+  private shouldInjectUI(downloadMetadata: DownloadMetadata): boolean {
+    if (!downloadMetadata) return false;
+    const {flavors, captions, attachments, imageDownloadUrl} = downloadMetadata;
+    if (flavors.length || imageDownloadUrl) {
+      return true;
+    }
+    // getting here means that there are no flavors and there is no image (for example, a youtube entry with captions)
+    const {displayCaptions, displayAttachments} = this.downloadPluginManager.downloadPlugin.config;
+    if (captions.length && !attachments.length && !displayCaptions) {
+      return false;
+    }
+    if (attachments.length && !captions.length && !displayAttachments) {
+      return false;
+    }
+    return true;
+  }
+
   async loadMedia() {
     await this.ready;
 
     this.downloadPluginManager.showOverlay = false;
     const downloadMetadata = await this.downloadPluginManager.getDownloadMetadata(true);
 
-    if (downloadMetadata) {
+    if (this.shouldInjectUI(downloadMetadata)) {
       this.logger.debug('Download is supported for current entry');
       this.injectOverlayComponents(downloadMetadata);
     }

--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -37,10 +37,6 @@ class DownloadService {
     Object.assign(metadata, assets);
     metadata!.imageDownloadUrl = await this.handleImageDownload();
 
-    if (!metadata?.flavors.length && !metadata?.captions.length && !metadata?.attachments.length && !metadata.imageDownloadUrl) {
-      return null;
-    }
-
     if (metadata?.flavors.length || metadata?.captions.length || metadata?.attachments.length) {
       const downloadUrls: Map<string, string> = await this.getDownloadUrls(metadata);
 

--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -37,6 +37,10 @@ class DownloadService {
     Object.assign(metadata, assets);
     metadata!.imageDownloadUrl = await this.handleImageDownload();
 
+    if (!metadata?.flavors.length && !metadata?.captions.length && !metadata?.attachments.length && !metadata.imageDownloadUrl) {
+      return null;
+    }
+
     if (metadata?.flavors.length || metadata?.captions.length || metadata?.attachments.length) {
       const downloadUrls: Map<string, string> = await this.getDownloadUrls(metadata);
 


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when loading a YT entry and clicking the download icon button, there is a source to download (with image icon), although there are no flavors for youtube entries.

**solution:**
render download item for image only if `imageUrl` has a value; render sources (default and flavors) only if array of flavors is not empty - it is possible to have a youtube entry, which has no flavors, but has captions which we would like to allow downloading.

Solves FEC-13455

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
