### PR TITLE
fix(SUP-39294): Page refreshes after clicking on player buttons

### DIFF
--- a/src/components/download-overlay-button/download-overlay-button.tsx
+++ b/src/components/download-overlay-button/download-overlay-button.tsx
@@ -16,7 +16,7 @@ const DownloadOverlayButton = withText({
   return (
     <div data-testid="download-overlay-button">
       <Tooltip label={downloadLabel}>
-        <button aria-label={downloadLabel} tabIndex={0} className={`${KalturaPlayer.ui.style.upperBarIcon}`} ref={setRef}>
+        <button type="button" aria-label={downloadLabel} tabIndex={0} className={`${KalturaPlayer.ui.style.upperBarIcon}`} ref={setRef}>
           <Icon id={`download-overlay-icon`} path={DOWNLOAD} viewBox={`0 0 32 32`} />
         </button>
       </Tooltip>


### PR DESCRIPTION
### Description of the Changes

**issue:**
When embed player in a form element and click on the plugin button, the page refreshes.

**solution:**
add type=button on the plugin button

solves [SUP-39294](https://kaltura.atlassian.net/browse/SUP-39294)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-39294]: https://kaltura.atlassian.net/browse/SUP-39294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ