### PR TITLE
fix(FEC-13473): Player v7 | Playlist | Download button is being duplicated.

### DIFF
--- a/src/download.tsx
+++ b/src/download.tsx
@@ -77,6 +77,10 @@ class Download extends KalturaPlayer.core.BasePlugin {
   };
 
   private injectOverlayComponents(downloadMetadata: DownloadMetadata) {
+    if (this.iconId > 0) {
+      return;
+    }
+
     this.iconId = this.upperBarManager.add({
       label: (<Text id="download.download">Download</Text>) as never,
       svgIcon: {


### PR DESCRIPTION
### Description of the Changes

Due to the way KMS handles playlists, loadMedia callback is called twice without a reset, which causes the upper bar icon to be added twice
Solution - add a check that upper bar icon was not already added

Resolves FEC-13473

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
