### PR TITLE
fix(FEC-13517): Wrong and inconsistent order of plugins

### DIFF
--- a/src/download.tsx
+++ b/src/download.tsx
@@ -8,7 +8,7 @@ import {DownloadPluginManager} from './download-plugin-manager';
 
 import {OnClickEvent} from '@playkit-js/common';
 import {ui} from '@playkit-js/kaltura-player-js';
-const {Text} = ui.preacti18n;
+import { pluginName } from "./index";
 const {ReservedPresetNames} = ui;
 const PRESETS = [ReservedPresetNames.Playback, ReservedPresetNames.Img];
 
@@ -79,10 +79,15 @@ class Download extends KalturaPlayer.core.BasePlugin {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     this.iconId = this.upperBarManager.add({
-      label: (<Text id="download.download">Download</Text>) as never,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      ariaLabel: (<Text id="download.download">Download</Text>) as never,
+      displayName: 'Download',
+      order: 40,
       svgIcon: {
-        viewBox: '0 0 32 32',
         path: DOWNLOAD
       },
       onClick: this._handleClick as any,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,6 @@ const NAME = __NAME__;
 export {Download as Plugin};
 export {VERSION, NAME};
 
-const pluginName = 'download';
+export const pluginName = 'download';
 
 KalturaPlayer.core.registerPlugin(pluginName, Download);


### PR DESCRIPTION
### Description of the Changes


**fix: Wrong and inconsistent order of plugins**

**fix: Plugins buttons sometimes display with the wrong icon**

**solves: [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517) [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517)**

[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Related Prs
https://github.com/kaltura/playkit-js-ui-managers/pull/51
https://github.com/kaltura/playkit-js-transcript/pull/175
https://github.com/kaltura/playkit-js-share/pull/38
https://github.com/kaltura/playkit-js-moderation/pull/74
https://github.com/kaltura/playkit-js-playlist/pull/53
https://github.com/kaltura/playkit-js-related/pull/61
https://github.com/kaltura/playkit-js-navigation/pull/348
https://github.com/kaltura/playkit-js-info/pull/90
