### PR TITLE
fix(ADA-490): [V7-Acc] SVG icons need to be hidden from screen reader update

### DIFF
--- a/src/components/download-overlay-button/download-overlay-button.tsx
+++ b/src/components/download-overlay-button/download-overlay-button.tsx
@@ -17,7 +17,7 @@ const DownloadOverlayButton = withText({
     <div data-testid="download-overlay-button">
       <Tooltip label={downloadLabel}>
         <button type="button" aria-label={downloadLabel} tabIndex={0} className={`${KalturaPlayer.ui.style.upperBarIcon}`} ref={setRef}>
-          <Icon id={`download-overlay-icon`} path={DOWNLOAD} viewBox={`0 0 32 32`} />
+          <Icon id={`download-overlay-icon`} path={DOWNLOAD} viewBox={`0 0 32 32`} hidden="true" />
         </button>
       </Tooltip>
     </div>


### PR DESCRIPTION
### Description of the Changes

Adding "aria-hidden" to the download icon

Resolves [ADA-490](https://kaltura.atlassian.net/browse/ADA-490)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
