### PR TITLE
fix(SUP-41001): Download button not available

### DIFF
--- a/src/components/captions-list/captions-list.tsx
+++ b/src/components/captions-list/captions-list.tsx
@@ -57,7 +57,7 @@ export const CaptionsList = withText({
 
   const _renderCaptions = (captions: Array<KalturaCaptionAsset>) => {
     return captions.map((caption: KalturaCaptionAsset) => {
-      if (!caption.isDefault || caption.id !== defaultCaptions?.id) {
+      if ((!caption.isDefault || caption.id !== defaultCaptions?.id) && caption.downloadUrl) {
         return _renderCaption(caption);
       }
     });

--- a/src/providers/get-download-url-loader.ts
+++ b/src/providers/get-download-url-loader.ts
@@ -29,9 +29,9 @@ export class DownloadUrlLoader implements ILoader {
     this._flavors = flavors;
     this._captions = captions;
     this._attachments = attachments;
-    this.addRequest(captions, 'caption_captionAsset', 'getUrl');
     this.addRequest(flavors, 'flavorasset', 'getUrl');
     this.addRequest(attachments, 'attachment_attachmentAsset', 'getUrl');
+    this.addRequest(captions, 'caption_captionAsset', 'getUrl');
   }
 
   addRequest(items: any[], service: string, action: string): void {
@@ -56,7 +56,12 @@ export class DownloadUrlLoader implements ILoader {
   set response(response: any) {
     const urls: Map<string, string> = new Map();
     for (let index = 0; index < this._requests.length; index++) {
-      urls.set(this._requests[index].params.id, response[index].data);
+      if (this._requests[index].service === 'caption_captionAsset') {
+        const id = response[index]?.data.match(/captionAssetId\/([^\/]+)/)[1];
+        urls.set(id, response[index]?.data);
+      } else {
+        urls.set(this._requests[index].params.id, response[index]?.data);
+      }
     }
     this._response.urls = urls;
   }

--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -65,7 +65,8 @@ class DownloadService {
 
     const data = await this.player.provider.doRequest(
       [{loader: DownloadUrlLoader, params: {flavors: metadata?.flavors, captions: metadata?.captions, attachments: metadata?.attachments}}],
-      ks
+      ks,
+      false
     );
     if (data && data.has(DownloadUrlLoader.id)) {
       const urlsLoader = data.get(DownloadUrlLoader.id);


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When there is one caption on status "processing" the download button is not displayed on the player even if we have additional captions on the entry 

**Root cause:**
There is request for BE to get all the urls for the captions, the request for the caption with status "processing" return kalturaApiException so all the request returns as error as a result the download plugin is not displayed.

**Solution:**
Send "false" in the doRequest as "requestsMustSucceed" so even if one of the caption is not ready the response returns with the other urls.
Since the exception result is removed from the response, the response and the request arrays is not necessarily arranged in the same indexes so set the urls according to the captionAssetId from the url.

part of the fix here - https://github.com/kaltura/playkit-js-providers/pull/237

Solves [SUP-41001](https://kaltura.atlassian.net/browse/SUP-41001)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-41001]: https://kaltura.atlassian.net/browse/SUP-41001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ