### PR TITLE
fix(FEC-13868): Player v7 | Download | Default language is being duplicated on kms.

### DIFF
--- a/src/components/captions-list/captions-list.tsx
+++ b/src/components/captions-list/captions-list.tsx
@@ -57,7 +57,7 @@ export const CaptionsList = withText({
 
   const _renderCaptions = (captions: Array<KalturaCaptionAsset>) => {
     return captions.map((caption: KalturaCaptionAsset) => {
-      if ((!caption.isDefault || caption.id !== defaultCaptions?.id) && caption.downloadUrl) {
+      if (!caption.isDefault && caption.id !== defaultCaptions?.id && caption.downloadUrl) {
         return _renderCaption(caption);
       }
     });


### PR DESCRIPTION
### Description of the Changes

**Issue:**
The first captions is being duplicated in the caption list

**Root cause:**
If there is no default caption (on the entry) player set the first captions form the list as the default and displays it on the download dialog, since caption.isDefault returns false we display this captions also in the hide captions so when user click on "More captions" he will see the first caption again.

**Solution:**
Check if caption is not the default by the user **and** it's not the default by the player.

Solves [FEC-13868](https://kaltura.atlassian.net/browse/FEC-13868)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13868]: https://kaltura.atlassian.net/browse/FEC-13868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ