### PR TITLE
fix(FEC-13889): download_close event being reported too many times

### DIFF
--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -128,7 +128,7 @@ const DownloadOverlay = withText({
               <A11yWrapper
                 onClick={(e: OnClickEvent, byKeyboard: boolean) => {
                   updateOverlay(false);
-                  downloadPluginManager.showOverlay = false;
+                  downloadPluginManager.setShowOverlay(false);
                   if (byKeyboard) {
                     setFocus();
                   }

--- a/src/download-plugin-manager.tsx
+++ b/src/download-plugin-manager.tsx
@@ -65,7 +65,7 @@ class DownloadPluginManager extends KalturaPlayer.core.FakeEventTarget {
     });
   }
 
-  set showOverlay(overlayVisible: boolean) {
+  setShowOverlay(overlayVisible: boolean, byUserInteraction = true): void {
     this._showOverlay = overlayVisible;
 
     if (this._showOverlay) {
@@ -79,7 +79,9 @@ class DownloadPluginManager extends KalturaPlayer.core.FakeEventTarget {
         this.downloadPlugin.player.play();
         this.playOnClose = false;
       }
-      this.dispatchEvent(new KalturaPlayer.core.FakeEvent(DownloadEvent.HIDE_OVERLAY));
+      if (byUserInteraction) {
+        this.dispatchEvent(new KalturaPlayer.core.FakeEvent(DownloadEvent.HIDE_OVERLAY));
+      }
     }
   }
 

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -87,7 +87,11 @@ class Download extends KalturaPlayer.core.BasePlugin {
     }
 
     if (this.store.getState().shell['activePresetName'] !== ReservedPresetNames.MiniAudioUI) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       this.iconId = this.upperBarManager.add({
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         ariaLabel: (<Text id="download.download">Download</Text>) as never,
         displayName: 'Download',
         order: 40,

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -98,6 +98,7 @@ class Download extends KalturaPlayer.core.BasePlugin {
         component: () => {
           return <DownloadOverlayButton setRef={this._setPluginButtonRef} />;
         },
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error - TS2322: Type string[] is not assignable to type ReservedPresetName[]
         presets: PRESETS.filter(presetName => presetName !== ReservedPresetNames.MiniAudioUI)
       }) as number;

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -103,7 +103,7 @@ class Download extends KalturaPlayer.core.BasePlugin {
           return <DownloadOverlayButton setRef={this._setPluginButtonRef} />;
         },
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error - TS2322: Type string[] is not assignable to type ReservedPresetName[]
+        // @ts-ignore
         presets: PRESETS.filter(presetName => presetName !== ReservedPresetNames.MiniAudioUI)
       }) as number;
     }

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -66,17 +66,13 @@ class Download extends KalturaPlayer.core.BasePlugin {
     });
   }
 
-  showOverlay(): void {
-    this.downloadPluginManager.showOverlay = true;
-  }
-
   private _setPluginButtonRef = (ref: HTMLButtonElement) => {
     this._pluginButtonRef = ref;
   };
 
   private _handleClick = (event: OnClickEvent, byKeyboard: boolean) => {
     this.triggeredByKeyboard = byKeyboard;
-    this.downloadPluginManager.showOverlay = !this.downloadPluginManager.showOverlay;
+    this.downloadPluginManager.setShowOverlay(!this.downloadPluginManager.showOverlay);
   };
 
   private _focusPluginButton = () => {
@@ -106,7 +102,8 @@ class Download extends KalturaPlayer.core.BasePlugin {
         component: () => {
           return <DownloadOverlayButton setRef={this._setPluginButtonRef} />;
         },
-
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         presets: PRESETS.filter(presetName => presetName !== ReservedPresetNames.MiniAudioUI)
       }) as number;
     }
@@ -141,7 +138,7 @@ class Download extends KalturaPlayer.core.BasePlugin {
   async loadMedia() {
     await this.ready;
 
-    this.downloadPluginManager.showOverlay = false;
+    this.downloadPluginManager.setShowOverlay(false, false);
     const downloadMetadata = await this.downloadPluginManager.getDownloadMetadata(true);
 
     if (this.shouldInjectUI(downloadMetadata)) {

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -87,11 +87,7 @@ class Download extends KalturaPlayer.core.BasePlugin {
     }
 
     if (this.store.getState().shell['activePresetName'] !== ReservedPresetNames.MiniAudioUI) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       this.iconId = this.upperBarManager.add({
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         ariaLabel: (<Text id="download.download">Download</Text>) as never,
         displayName: 'Download',
         order: 40,
@@ -102,8 +98,7 @@ class Download extends KalturaPlayer.core.BasePlugin {
         component: () => {
           return <DownloadOverlayButton setRef={this._setPluginButtonRef} />;
         },
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error - TS2322: Type string[] is not assignable to type ReservedPresetName[]
         presets: PRESETS.filter(presetName => presetName !== ReservedPresetNames.MiniAudioUI)
       }) as number;
     }


### PR DESCRIPTION
### Description of the Changes

**the issue:**
`download_close` event is being reported to analytics too many times.
whenever a media is loaded, we set `showOverlay` to `false`, which sends event to kava as if the overlay was closed by user (which was not).

**solution:**
distinguish between when we set `showOverlay` value for managing its state, and when we set the value because of a user interaction.

Solves FEC-13889

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
