### PR TITLE
fix(FEC-13728): bring back showOverlay api

### DIFF
--- a/src/download.tsx
+++ b/src/download.tsx
@@ -66,6 +66,10 @@ class Download extends KalturaPlayer.core.BasePlugin {
     });
   }
 
+  showOverlay(): void {
+    this.downloadPluginManager.setShowOverlay(true);
+  }
+
   private _setPluginButtonRef = (ref: HTMLButtonElement) => {
     this._pluginButtonRef = ref;
   };


### PR DESCRIPTION
### Description of the Changes

**the issue:**
`showOverlay` api was removed because it was not clear who is using it, which caused a regression in audio player when clicking on download button.

**solution:**
bring back the api.

Solves FEC-13728

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
