### PR TITLE
fix(FEC-14086): Player v7 | Download plugin overlay doesnt match figma.

### DIFF
--- a/src/components/download-overlay/download-overlay.scss
+++ b/src/components/download-overlay/download-overlay.scss
@@ -65,3 +65,11 @@
     }
   }
 }
+
+:global(.download-overlay-active .playkit-overlay-active .playkit-interactive-area) {
+  filter: none !important;
+}
+
+:global(.download-overlay-active .playkit-player.playkit-overlay-active .overlay-portal) {
+  z-index: 2 !important;
+}

--- a/src/download-plugin-manager.tsx
+++ b/src/download-plugin-manager.tsx
@@ -13,12 +13,10 @@ class DownloadPluginManager extends KalturaPlayer.core.FakeEventTarget {
   private downloadService: any;
   private downloadMetadata: DownloadMetadata = null;
   private playOnClose = false;
-  private player;
 
   constructor(public downloadPlugin: Download) {
     super();
     this.downloadService = new DownloadService(downloadPlugin.player, downloadPlugin.logger);
-    this.player = downloadPlugin.player;
   }
 
   async getDownloadMetadata(refresh = false): Promise<DownloadMetadata> {
@@ -71,7 +69,7 @@ class DownloadPluginManager extends KalturaPlayer.core.FakeEventTarget {
     this._showOverlay = overlayVisible;
 
     if (this._showOverlay) {
-      document.getElementById(this.player.config.targetId as string)?.classList.add('download-overlay-active');
+      document.getElementById(this.downloadPlugin.player.config.targetId as string)?.classList.add('download-overlay-active');
 
       if (!this.downloadPlugin.player.paused) {
         this.downloadPlugin.player.pause();
@@ -79,7 +77,7 @@ class DownloadPluginManager extends KalturaPlayer.core.FakeEventTarget {
       }
       this.dispatchEvent(new KalturaPlayer.core.FakeEvent(DownloadEvent.SHOW_OVERLAY, {byKeyboard: this.downloadPlugin.triggeredByKeyboard}));
     } else {
-      document.getElementById(this.player.config.targetId as string)?.classList.remove('download-overlay-active');
+      document.getElementById(this.downloadPlugin.player.config.targetId as string)?.classList.remove('download-overlay-active');
 
       if (this.playOnClose) {
         this.downloadPlugin.player.play();

--- a/src/download-plugin-manager.tsx
+++ b/src/download-plugin-manager.tsx
@@ -13,10 +13,12 @@ class DownloadPluginManager extends KalturaPlayer.core.FakeEventTarget {
   private downloadService: any;
   private downloadMetadata: DownloadMetadata = null;
   private playOnClose = false;
+  private player;
 
   constructor(public downloadPlugin: Download) {
     super();
     this.downloadService = new DownloadService(downloadPlugin.player, downloadPlugin.logger);
+    this.player = downloadPlugin.player;
   }
 
   async getDownloadMetadata(refresh = false): Promise<DownloadMetadata> {
@@ -69,12 +71,16 @@ class DownloadPluginManager extends KalturaPlayer.core.FakeEventTarget {
     this._showOverlay = overlayVisible;
 
     if (this._showOverlay) {
+      document.getElementById(this.player.config.targetId as string)?.classList.add('download-overlay-active');
+
       if (!this.downloadPlugin.player.paused) {
         this.downloadPlugin.player.pause();
         this.playOnClose = true;
       }
       this.dispatchEvent(new KalturaPlayer.core.FakeEvent(DownloadEvent.SHOW_OVERLAY, {byKeyboard: this.downloadPlugin.triggeredByKeyboard}));
     } else {
+      document.getElementById(this.player.config.targetId as string)?.classList.remove('download-overlay-active');
+
       if (this.playOnClose) {
         this.downloadPlugin.player.play();
         this.playOnClose = false;


### PR DESCRIPTION
### Description of the Changes

While overlay is active, remove blur from interactive area, and change z index of the overlay so that toasts will appear on top of it

Resolves FEC-14086

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
