### PR TITLE
fix: filter out flavors with height 0

### DIFF
--- a/src/components/sources-list/sources-list.tsx
+++ b/src/components/sources-list/sources-list.tsx
@@ -128,7 +128,7 @@ export const SourcesList = withText({
 
     const _renderFlavors = (flavors: Array<KalturaFlavorAsset>) => {
       return flavors.map((flavor: KalturaFlavorAsset) => {
-        if (flavor.downloadUrl && flavor.id !== defaultFlavor?.id) {
+        if (flavor.height > 0 && flavor.downloadUrl && flavor.id !== defaultFlavor?.id) {
           return _renderFlavor(flavor);
         }
       });


### PR DESCRIPTION
### Description of the Changes

Filter out flavors with height 0 to not show captions as sources

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
