### PR TITLE
fix(ADA-1514): Incorrect focus order is observed when Related Files button is activated.

### DIFF
--- a/src/components/attachments-list/attachments-list.tsx
+++ b/src/components/attachments-list/attachments-list.tsx
@@ -14,6 +14,7 @@ const {withText} = ui.preacti18n;
 interface AttachmentsListProps extends AssetsListProps {
   files: KalturaAttachmentAsset[];
   downloadPluginManager: DownloadPluginManager;
+  displayFirst: boolean;
   title?: string;
   ariaLabel?: string;
 }
@@ -21,7 +22,7 @@ interface AttachmentsListProps extends AssetsListProps {
 export const AttachmentsList = withText({
   title: 'download.attachments_label',
   ariaLabel: 'download.download_button_label_attachment'
-})(({files, downloadPluginManager, title, ariaLabel}: AttachmentsListProps) => {
+})(({files, downloadPluginManager, displayFirst, title, ariaLabel}: AttachmentsListProps) => {
   const _buildFileName = (attachment: KalturaAttachmentAsset) => {
     return attachment.title || attachment.fileName;
   };
@@ -36,6 +37,7 @@ export const AttachmentsList = withText({
         assetType={assetType.Attachments}
         iconFileType={icon}
         ariaLabel={ariaLabel}
+        displayFirst={displayFirst}
       />
     );
   };

--- a/src/components/attachments-list/attachments-list.tsx
+++ b/src/components/attachments-list/attachments-list.tsx
@@ -14,7 +14,7 @@ const {withText} = ui.preacti18n;
 interface AttachmentsListProps extends AssetsListProps {
   files: KalturaAttachmentAsset[];
   downloadPluginManager: DownloadPluginManager;
-  displayFirst: boolean;
+  shouldFocus: boolean;
   title?: string;
   ariaLabel?: string;
 }
@@ -22,7 +22,7 @@ interface AttachmentsListProps extends AssetsListProps {
 export const AttachmentsList = withText({
   title: 'download.attachments_label',
   ariaLabel: 'download.download_button_label_attachment'
-})(({files, downloadPluginManager, displayFirst, title, ariaLabel}: AttachmentsListProps) => {
+})(({files, downloadPluginManager, shouldFocus, title, ariaLabel}: AttachmentsListProps) => {
   const _buildFileName = (attachment: KalturaAttachmentAsset) => {
     return attachment.title || attachment.fileName;
   };
@@ -37,7 +37,7 @@ export const AttachmentsList = withText({
         assetType={assetType.Attachments}
         iconFileType={icon}
         ariaLabel={ariaLabel}
-        displayFirst={displayFirst}
+        shouldFocus={shouldFocus}
       />
     );
   };

--- a/src/components/captions-list/captions-list.tsx
+++ b/src/components/captions-list/captions-list.tsx
@@ -14,6 +14,7 @@ const {withText} = ui.preacti18n;
 interface CaptionsListProps extends AssetsListProps {
   files: KalturaCaptionAsset[];
   downloadPluginManager: DownloadPluginManager;
+  displayFirst: boolean;
   fileName: string;
   moreCaptionsLabel?: string;
   lessCaptionsLabel?: string;
@@ -24,7 +25,7 @@ export const CaptionsList = withText({
   moreCaptionsLabel: 'download.more_captions_label',
   lessCaptionsLabel: 'download.less_captions_label',
   ariaLabel: 'download.download_button_label_captions'
-})(({files, downloadPluginManager, fileName, moreCaptionsLabel, lessCaptionsLabel, ariaLabel}: CaptionsListProps) => {
+})(({files, downloadPluginManager, displayFirst, fileName, moreCaptionsLabel, lessCaptionsLabel, ariaLabel}: CaptionsListProps) => {
   const captions: KalturaCaptionAsset[] = files;
   let defaultCaptions: KalturaCaptionAsset | undefined;
 
@@ -54,6 +55,7 @@ export const CaptionsList = withText({
         assetType={assetType.Captions}
         iconFileType={<CommonIcon name={'closedCaptions'} />}
         ariaLabel={ariaLabel}
+        displayFirst={displayFirst}
       />
     );
   };

--- a/src/components/captions-list/captions-list.tsx
+++ b/src/components/captions-list/captions-list.tsx
@@ -14,7 +14,7 @@ const {withText} = ui.preacti18n;
 interface CaptionsListProps extends AssetsListProps {
   files: KalturaCaptionAsset[];
   downloadPluginManager: DownloadPluginManager;
-  displayFirst: boolean;
+  shouldFocus: boolean;
   fileName: string;
   moreCaptionsLabel?: string;
   lessCaptionsLabel?: string;
@@ -25,7 +25,7 @@ export const CaptionsList = withText({
   moreCaptionsLabel: 'download.more_captions_label',
   lessCaptionsLabel: 'download.less_captions_label',
   ariaLabel: 'download.download_button_label_captions'
-})(({files, downloadPluginManager, displayFirst, fileName, moreCaptionsLabel, lessCaptionsLabel, ariaLabel}: CaptionsListProps) => {
+})(({files, downloadPluginManager, shouldFocus, fileName, moreCaptionsLabel, lessCaptionsLabel, ariaLabel}: CaptionsListProps) => {
   const captions: KalturaCaptionAsset[] = files;
   let defaultCaptions: KalturaCaptionAsset | undefined;
 
@@ -55,7 +55,7 @@ export const CaptionsList = withText({
         assetType={assetType.Captions}
         iconFileType={<CommonIcon name={'closedCaptions'} />}
         ariaLabel={ariaLabel}
-        displayFirst={displayFirst}
+        shouldFocus={shouldFocus}
       />
     );
   };

--- a/src/components/download-item/download-item.tsx
+++ b/src/components/download-item/download-item.tsx
@@ -25,7 +25,7 @@ interface DownloadItemProps {
   iconFileType: ComponentChildren;
   isDefault?: boolean;
   player: KalturaPlayer;
-  displayFirst?: boolean;
+  shouldFocus?: boolean;
 }
 
 export const DownloadItem = withText({
@@ -48,12 +48,12 @@ export const DownloadItem = withText({
       iconFileType,
       isDefault,
       player,
-      displayFirst
+      shouldFocus
     }: DownloadItemProps) => {
       const downloadItemRef = useRef<HTMLDivElement>(null);
 
       useEffect(() => {
-        if (isDefault || displayFirst) {
+        if (isDefault || shouldFocus) {
           downloadItemRef.current?.focus();
         }
       }, []);

--- a/src/components/download-item/download-item.tsx
+++ b/src/components/download-item/download-item.tsx
@@ -25,6 +25,7 @@ interface DownloadItemProps {
   iconFileType: ComponentChildren;
   isDefault?: boolean;
   player: KalturaPlayer;
+  displayFirst?: boolean;
 }
 
 export const DownloadItem = withText({
@@ -46,12 +47,15 @@ export const DownloadItem = withText({
       downloadUrl,
       iconFileType,
       isDefault,
-      player
+      player,
+      displayFirst
     }: DownloadItemProps) => {
       const downloadItemRef = useRef<HTMLDivElement>(null);
 
       useEffect(() => {
         if (isDefault) {
+          downloadItemRef.current?.focus();
+        } else if (displayFirst) {
           downloadItemRef.current?.focus();
         }
       }, []);

--- a/src/components/download-item/download-item.tsx
+++ b/src/components/download-item/download-item.tsx
@@ -53,9 +53,7 @@ export const DownloadItem = withText({
       const downloadItemRef = useRef<HTMLDivElement>(null);
 
       useEffect(() => {
-        if (isDefault) {
-          downloadItemRef.current?.focus();
-        } else if (displayFirst) {
+        if (isDefault || displayFirst) {
           downloadItemRef.current?.focus();
         }
       }, []);

--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -70,12 +70,23 @@ const DownloadOverlay = withText({
 
       const renderCaptions = () => {
         return (
-          <CaptionsList files={downloadMetadata!.captions} downloadPluginManager={downloadPluginManager} fileName={downloadMetadata!.fileName} />
+          <CaptionsList
+            files={downloadMetadata!.captions}
+            downloadPluginManager={downloadPluginManager}
+            fileName={downloadMetadata!.fileName}
+            displayFirst={!shouldRenderSources}
+          />
         );
       };
 
       const renderAttachments = () => {
-        return <AttachmentsList files={downloadMetadata!.attachments} downloadPluginManager={downloadPluginManager} />;
+        return (
+          <AttachmentsList
+            files={downloadMetadata!.attachments}
+            downloadPluginManager={downloadPluginManager}
+            displayFirst={!shouldRenderSources && !shouldRenderCaptions}
+          />
+        );
       };
 
       const shouldRenderSources = downloadConfig.displaySources && (downloadMetadata!.flavors.length || downloadMetadata!.imageDownloadUrl);

--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -74,7 +74,7 @@ const DownloadOverlay = withText({
             files={downloadMetadata!.captions}
             downloadPluginManager={downloadPluginManager}
             fileName={downloadMetadata!.fileName}
-            displayFirst={!shouldRenderSources}
+            shouldFocus={!shouldRenderSources}
           />
         );
       };
@@ -84,7 +84,7 @@ const DownloadOverlay = withText({
           <AttachmentsList
             files={downloadMetadata!.attachments}
             downloadPluginManager={downloadPluginManager}
-            displayFirst={!shouldRenderSources && !shouldRenderCaptions}
+            shouldFocus={!shouldRenderSources && !shouldRenderCaptions}
           />
         );
       };

--- a/src/components/sources-list/sources-list.tsx
+++ b/src/components/sources-list/sources-list.tsx
@@ -108,7 +108,8 @@ export const SourcesList = withText({
       downloadUrl: string,
       icon: ComponentChildren,
       isDefault = false,
-      ariaLabel: string
+      ariaLabel: string,
+      displayFirst: boolean
     ) => {
       return (
         <DownloadItem
@@ -121,11 +122,12 @@ export const SourcesList = withText({
           assetType={assetType.Media}
           isDefault={isDefault}
           ariaLabel={ariaLabel}
+          displayFirst={displayFirst}
         />
       );
     };
 
-    const _renderFlavor = (flavor: KalturaFlavorAsset, isDefault = false) => {
+    const _renderFlavor = (flavor: KalturaFlavorAsset, isDefault = false, displayFirst = true) => {
       return _renderDownloadItem(
         flavor.id,
         `${fileName}.${flavor.fileExt}`,
@@ -133,14 +135,15 @@ export const SourcesList = withText({
         flavor.downloadUrl,
         _getPlayIcon(flavor),
         isDefault,
-        ariaLabel!
+        ariaLabel!,
+        displayFirst
       );
     };
 
     const _renderFlavors = (flavors: Array<KalturaFlavorAsset>) => {
       return flavors.reduce((acc: Array<ComponentChildren>, curr: KalturaFlavorAsset) => {
         if (curr.downloadUrl && curr.id !== defaultFlavor?.id) {
-          return [...acc, _renderFlavor(curr)];
+          return [...acc, _renderFlavor(curr, false, false)];
         }
         return acc;
       }, []);
@@ -162,7 +165,7 @@ export const SourcesList = withText({
 
     const _renderSources = () => {
       if (imageUrl) {
-        return _renderDownloadItem('1', fileName, '', imageUrl, _getImageIcon(), true, ariaLabel!);
+        return _renderDownloadItem('1', fileName, '', imageUrl, _getImageIcon(), true, ariaLabel!, false);
       } else if (flavors.length > 0) {
         return _renderExpandableFlavors();
       }

--- a/src/components/sources-list/sources-list.tsx
+++ b/src/components/sources-list/sources-list.tsx
@@ -109,7 +109,7 @@ export const SourcesList = withText({
       icon: ComponentChildren,
       isDefault = false,
       ariaLabel: string,
-      displayFirst: boolean
+      shouldFocus: boolean
     ) => {
       return (
         <DownloadItem
@@ -122,12 +122,12 @@ export const SourcesList = withText({
           assetType={assetType.Media}
           isDefault={isDefault}
           ariaLabel={ariaLabel}
-          displayFirst={displayFirst}
+          shouldFocus={shouldFocus}
         />
       );
     };
 
-    const _renderFlavor = (flavor: KalturaFlavorAsset, isDefault = false, displayFirst = true) => {
+    const _renderFlavor = (flavor: KalturaFlavorAsset, isDefault = false, shouldFocus = true) => {
       return _renderDownloadItem(
         flavor.id,
         `${fileName}.${flavor.fileExt}`,
@@ -136,7 +136,7 @@ export const SourcesList = withText({
         _getPlayIcon(flavor),
         isDefault,
         ariaLabel!,
-        displayFirst
+        shouldFocus
       );
     };
 


### PR DESCRIPTION
### Description of the Changes

**Issue:** 
When open the download plugin with tab key, focus move to the first element in the modal only if the displayFlavors config is enabled. in case of display only captions or attachment, focus move to the body and not not specific element.

**Fix:**
Add functionality to check if captions/attachment or flavors will be displayed first in the modal, then move the focus according to that and not only according isDefault value (that relevant only to diaplyFlavors and not the rest of the configuration)

Solves [ADA-1514](https://kaltura.atlassian.net/browse/ADA-1514)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-1514]: https://kaltura.atlassian.net/browse/ADA-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ