### PR TITLE
fix(ADA-1514): Incorrect focus order is observed when Related Files button is activated.

### DIFF
--- a/src/components/attachments-list/attachments-list.tsx
+++ b/src/components/attachments-list/attachments-list.tsx
@@ -27,7 +27,14 @@ export const AttachmentsList = withText({
     return attachment.title || attachment.fileName;
   };
 
-  const _renderDownloadItem = (key: string, fileName: string, downloadUrl: string, icon: ComponentChildren, ariaLabel: string) => {
+  const _renderDownloadItem = (
+    key: string,
+    fileName: string,
+    downloadUrl: string,
+    icon: ComponentChildren,
+    ariaLabel: string,
+    shouldFocusItem: boolean
+  ) => {
     return (
       <DownloadItem
         downloadPluginManager={downloadPluginManager}
@@ -37,14 +44,22 @@ export const AttachmentsList = withText({
         assetType={assetType.Attachments}
         iconFileType={icon}
         ariaLabel={ariaLabel}
-        shouldFocus={shouldFocus}
+        shouldFocus={shouldFocusItem}
       />
     );
   };
 
   const _renderAttachments = (attachments: Array<KalturaAttachmentAsset>) => {
-    return attachments.map((attachment: KalturaAttachmentAsset) => {
-      return _renderDownloadItem(attachment.id, _buildFileName(attachment), attachment.downloadUrl, getIconByFileExt(attachment.fileExt), ariaLabel!);
+    return attachments.map((attachment: KalturaAttachmentAsset, index) => {
+      const shouldFocusItem = index === 0 ? shouldFocus : false;
+      return _renderDownloadItem(
+        attachment.id,
+        _buildFileName(attachment),
+        attachment.downloadUrl,
+        getIconByFileExt(attachment.fileExt),
+        ariaLabel!,
+        shouldFocusItem
+      );
     });
   };
 

--- a/src/components/captions-list/captions-list.tsx
+++ b/src/components/captions-list/captions-list.tsx
@@ -44,7 +44,14 @@ export const CaptionsList = withText({
     return `${fileName}.${caption.fileExt}`;
   };
 
-  const _renderDownloadItem = (key: string, fileName: string, languageLabel: string, downloadUrl: string, ariaLabel: string) => {
+  const _renderDownloadItem = (
+    key: string,
+    fileName: string,
+    languageLabel: string,
+    downloadUrl: string,
+    ariaLabel: string,
+    shouldFocusItem: boolean
+  ) => {
     return (
       <DownloadItem
         downloadPluginManager={downloadPluginManager}
@@ -55,13 +62,14 @@ export const CaptionsList = withText({
         assetType={assetType.Captions}
         iconFileType={<CommonIcon name={'closedCaptions'} />}
         ariaLabel={ariaLabel}
-        shouldFocus={shouldFocus}
+        shouldFocus={shouldFocusItem}
       />
     );
   };
 
-  const _renderCaption = (caption: KalturaCaptionAsset) => {
-    return _renderDownloadItem(caption.id, _buildFileName(caption), caption.label, caption.downloadUrl, ariaLabel!);
+  const _renderCaption = (caption: KalturaCaptionAsset, firstItemInList?: boolean) => {
+    const shouldFocusItem = !!(shouldFocus && firstItemInList);
+    return _renderDownloadItem(caption.id, _buildFileName(caption), caption.label, caption.downloadUrl, ariaLabel!, shouldFocusItem);
   };
 
   const _renderCaptions = (captions: Array<KalturaCaptionAsset>) => {
@@ -75,7 +83,7 @@ export const CaptionsList = withText({
   const _renderExpandableCaptions = () => {
     return (
       <ExpandableContainer
-        defaultItem={_renderCaption(defaultCaptions!)}
+        defaultItem={_renderCaption(defaultCaptions!, true)}
         restOfItems={_renderCaptions(captions)}
         showMoreLabel={moreCaptionsLabel!}
         showLessLabel={lessCaptionsLabel!}
@@ -85,7 +93,7 @@ export const CaptionsList = withText({
 
   return (
     <div className={styles.captionsContainer} data-testid={'download-overlay-captions-container'}>
-      {captions.length > 1 ? _renderExpandableCaptions() : _renderCaption(defaultCaptions!)}
+      {captions.length > 1 ? _renderExpandableCaptions() : _renderCaption(defaultCaptions!, true)}
     </div>
   );
 });


### PR DESCRIPTION
### Description of the Changes

**Issue:** 
when we have more than one attachment/caption the focus move to the last item and not the first

**Solution:**
shouldFocus is sent as true to downloadItem only if this is the first item in the caption/attachment list and not for all item (and of course also only if this is the first list in the overlay)

improvement of #74

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
