### PR TITLE
fix(ADA-1747): [BofA] Marketting - Avoid the use of implicit headings

### DIFF
--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -142,7 +142,7 @@ const DownloadOverlay = withText({
                 }}
                 type="playkit-download">
                 <div data-testid="download-overlay" className={styles.downloadOverlay}>
-                  <div className={styles.header}>{downloadsLabel}</div>
+                  <h2 className={styles.header}>{downloadsLabel}</h2>
                   <div className={styles.fileInfoList}>
                     {shouldRenderSources || shouldRenderCaptions ? (
                       <div className={styles.sourcesCaptionsContainer}>


### PR DESCRIPTION
### Description of the Changes

Change download div element to h2 element (accessibility requirement) 

solves [ADA-1747](https://kaltura.atlassian.net/browse/ADA-1747)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-1747]: https://kaltura.atlassian.net/browse/ADA-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ