### PR TITLE
fix(ADA-1745) - Include modal title into close button aria-label 

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -54,7 +54,8 @@
                 source_label: 'Source',
                 more_captions_label: 'More captions',
                 less_captions_label: 'Less captions',
-                attachments_label: 'Attachments'
+                attachments_label: 'Attachments',
+                close: 'Close Download'
               }
             }
           }

--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -32,6 +32,7 @@ interface DownloadOverlayProps extends AssetsListProps {
   additionalStreams?: string;
   captionsLabel?: string;
   closeLabel?: string;
+  closeDownloadLabel?: string;
   setFocus: () => void;
   downloadMetadatas: DownloadMetadata[];
   updateOverlay: (isOpen: boolean) => void;
@@ -42,7 +43,8 @@ const DownloadOverlay = withText({
   closeLabel: 'overlay.close',
   mainStream: 'download.main_stream',
   additionalStreams: 'download.additional_streams',
-  captionsLabel: 'download.captions'
+  captionsLabel: 'download.captions',
+  closeDownloadLabel: 'download.close'
 })(
   connect(
     null,
@@ -57,7 +59,8 @@ const DownloadOverlay = withText({
         additionalStreams,
         captionsLabel,
         downloadMetadatas,
-        updateOverlay
+        updateOverlay,
+        closeDownloadLabel
       }: DownloadOverlayProps) => {
         const [isVisible, setIsVisible] = useState(false);
         const mainSourceMetadata = downloadMetadatas[0];
@@ -136,7 +139,7 @@ const DownloadOverlay = withText({
             <FocusTrap active>
               <Overlay
                 open
-                closeAriaLabel="Close Download"
+                closeAriaLabel={closeDownloadLabel}
                 onClose={() => {
                   updateOverlay(false);
                   downloadPluginManager.setShowOverlay(false);

--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -136,6 +136,7 @@ const DownloadOverlay = withText({
             <FocusTrap active>
               <Overlay
                 open
+                closeAriaLabel="Close Download"
                 onClose={() => {
                   updateOverlay(false);
                   downloadPluginManager.setShowOverlay(false);

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -17,7 +17,8 @@
       "attachments_label": "Attachments",
       "main_stream": "Main stream",
       "additional_streams": "Additional streams",
-      "captions": "Captions"
+      "captions": "Captions",
+      "close": "Close Download"
     }
   }
 }


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/ADA-1745
It is related to  https://github.com/kaltura/playkit-js-ui/pull/984 and https://github.com/kaltura/playkit-js-info/pull/112

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
