### PR TITLE
fix(ADA-1736) - Tooltip strict position

### DIFF
--- a/src/components/download-overlay-button/download-overlay-button.tsx
+++ b/src/components/download-overlay-button/download-overlay-button.tsx
@@ -17,7 +17,7 @@ const DownloadOverlayButton = withText({
 })(({downloadLabel, setRef}: {setRef: (ref: HTMLButtonElement | null) => void; downloadLabel: string}) => {
   return (
     <div data-testid="download-overlay-button">
-      <Tooltip label={downloadLabel}>
+      <Tooltip label={downloadLabel} type="bottom-left" strictPosition={true}>
         <button type="button" aria-label={downloadLabel} tabIndex={0} className={`${ui.style.upperBarIcon}`} ref={setRef}>
           <Icon id={`download-overlay-icon`} path={DOWNLOAD} viewBox={`0 0 32 32`} hidden="true" />
         </button>


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/ADA-1736. 
It sets the Tooltip position to always be bottom-left.

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
