### PR TITLE
fix(SUP-51658): Player downloads not opening

### DIFF
--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -115,7 +115,8 @@ class DownloadService {
     if (data && data.has(DownloadUrlLoader.id)) {
       const urlsLoader = data.get(DownloadUrlLoader.id);
       urls = urlsLoader?.response?.urls;
-      urls = new Map([...urls].filter(([, value]) => value));
+      //filter out empty urls
+      urls = new Map([...urls].filter(([, url]) => !!url));
     }
 
     return urls;

--- a/src/services/download-service.ts
+++ b/src/services/download-service.ts
@@ -109,11 +109,13 @@ class DownloadService {
       // @ts-expect-error - Type 'typeof DownloadUrlLoader' is missing the following properties from type 'ILoader': requests, response, isValid
       [{loader: DownloadUrlLoader, params: {flavors: metadata?.flavors, captions: metadata?.captions, attachments: metadata?.attachments}}],
       ks,
+      false,
       false
     );
     if (data && data.has(DownloadUrlLoader.id)) {
       const urlsLoader = data.get(DownloadUrlLoader.id);
       urls = urlsLoader?.response?.urls;
+      urls = new Map([...urls].filter(([, value]) => value));
     }
 
     return urls;


### PR DESCRIPTION
issue:
download docx file for a costumer did not open correctly

root cause:
when do call for downloads items and get result with an error for some asset, the results mapping was wrong and mixed the asset id with url, after the error results was filtered out.

solution:
add flag if to remove error results

this pr is part of: https://github.com/kaltura/playkit-js-providers/pull/277

resolve [SUP-51658](https://kaltura.atlassian.net/browse/SUP-51658)



[SUP-51658]: https://kaltura.atlassian.net/browse/SUP-51658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ