### PR TITLE
feat(CR-616): Download S&C PDF from download plugin

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -49,6 +49,7 @@
                 download_button_label_video: 'Click to download the video',
                 download_button_label_captions: 'Click to download the captions',
                 download_button_label_attachment: 'Click to download the attachment',
+                download_button_label_summary_chapters: 'Click to download the summary and chapters',
                 select_quality_label: 'Select quality',
                 hide_label: 'Hide',
                 source_label: 'Source',

--- a/src/components/download-item/download-item.tsx
+++ b/src/components/download-item/download-item.tsx
@@ -6,6 +6,8 @@ import {DownloadPluginManager} from '../../download-plugin-manager';
 import {useEffect, useRef} from 'preact/hooks';
 import {core, KalturaPlayer, ui} from '@playkit-js/kaltura-player-js';
 import {DownloadEvent} from '../../event';
+import {assetType as asset} from '../../consts/asset-type';
+
 
 const {withText} = ui.preacti18n;
 const {FakeEvent} = core;
@@ -74,6 +76,13 @@ export const DownloadItem = withText({
                   description,
                   assetType,
                   isDefault: isDefault && isMainSource
+                })
+              );
+            } else if (assetType === asset.SummaryAndChapters) {
+              player.dispatchEvent(
+                new FakeEvent(DownloadEvent.DOWNLOAD_SUMMARY_AND_CHAPTERS_DOWNLOAD, {
+                  description,
+                  assetType,
                 })
               );
             } else {

--- a/src/components/download-item/download-item.tsx
+++ b/src/components/download-item/download-item.tsx
@@ -8,7 +8,6 @@ import {core, KalturaPlayer, ui} from '@playkit-js/kaltura-player-js';
 import {DownloadEvent} from '../../event';
 import {assetType as asset} from '../../consts/asset-type';
 
-
 const {withText} = ui.preacti18n;
 const {FakeEvent} = core;
 const {withPlayer} = ui.Components;
@@ -82,7 +81,7 @@ export const DownloadItem = withText({
               player.dispatchEvent(
                 new FakeEvent(DownloadEvent.DOWNLOAD_SUMMARY_AND_CHAPTERS_DOWNLOAD, {
                   description,
-                  assetType,
+                  assetType
                 })
               );
             } else {

--- a/src/components/download-overlay/download-overlay.tsx
+++ b/src/components/download-overlay/download-overlay.tsx
@@ -21,6 +21,7 @@ import * as styles from './download-overlay.scss';
 import {SourcesList} from '../sources-list';
 import {CaptionsList} from '../captions-list';
 import {AttachmentsList} from '../attachments-list';
+import {SummaryChaptersList} from '../summary-chapters-list';
 import {DownloadEvent} from '../../event';
 import {AssetsListProps} from '../../types/assets-list-props';
 
@@ -127,6 +128,16 @@ const DownloadOverlay = withText({
           );
         };
 
+        const renderSummaryAndChapters = () => {
+          return (
+            <SummaryChaptersList
+              downloadPluginManager={downloadPluginManager}
+              fileName={mainSourceMetadata!.fileName}
+              shouldFocus={!shouldRenderSources && !shouldRenderCaptions && !shouldRenderAttachments}
+            />
+          );
+        };
+
         const getShouldRenderSources = (sourceMetadata: DownloadMetadata) => {
           return sourceMetadata!.flavors.length || sourceMetadata!.imageDownloadUrl;
         };
@@ -134,6 +145,7 @@ const DownloadOverlay = withText({
         const shouldRenderSources = downloadConfig.displaySources && getShouldRenderSources(mainSourceMetadata);
         const shouldRenderCaptions = downloadConfig.displayCaptions && mainSourceMetadata!.captions.length;
         const shouldRenderAttachments = downloadConfig.displayAttachments && mainSourceMetadata!.attachments.length;
+        const showSummaryAndChapters = downloadPluginManager.showSummaryAndChapters;
 
         return isVisible ? (
           <OverlayPortal>
@@ -155,6 +167,7 @@ const DownloadOverlay = withText({
                         {shouldRenderCaptions && renderCaptions()}
                       </div>
                     ) : null}
+                    {showSummaryAndChapters && renderSummaryAndChapters()}
                     {shouldRenderAttachments && renderAttachments()}
                   </div>
                 </div>

--- a/src/components/summary-chapters-list/index.ts
+++ b/src/components/summary-chapters-list/index.ts
@@ -1,0 +1,2 @@
+import {SummaryChaptersList} from './summary-chapters-list';
+export {SummaryChaptersList};

--- a/src/components/summary-chapters-list/summary-chapters-list.scss
+++ b/src/components/summary-chapters-list/summary-chapters-list.scss
@@ -1,0 +1,15 @@
+@import '~@playkit-js/playkit-js-ui';
+@import '../../theme.scss';
+
+.summary-chapters-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  overflow: hidden;
+  padding: 4px;
+
+  .summary-chapters-label {
+    @include label;
+  }
+}

--- a/src/components/summary-chapters-list/summary-chapters-list.tsx
+++ b/src/components/summary-chapters-list/summary-chapters-list.tsx
@@ -1,4 +1,4 @@
-import {h, ComponentChildren} from 'preact';
+import {h} from 'preact';
 import {DownloadPluginManager} from '../../download-plugin-manager';
 import {DownloadItem} from '../download-item';
 import * as styles from './summary-chapters-list.scss';
@@ -9,18 +9,19 @@ import {Icon as CommonIcon} from '@playkit-js/common/dist/icon';
 import {ui} from '@playkit-js/kaltura-player-js';
 
 const {withText} = ui.preacti18n;
-const {Icon} = ui.components;
 
 interface SummaryChaptersListProps extends AssetsListProps {
   downloadPluginManager: DownloadPluginManager;
   shouldFocus: boolean;
   fileName: string;
   title?: string;
+  ariaLabel?: string;
 }
 
 export const SummaryChaptersList = withText({
-  title: 'download.summary_chapters_label'
-})(({downloadPluginManager, shouldFocus, fileName, title}: SummaryChaptersListProps) => {
+  title: 'download.summary_chapters_label',
+  ariaLabel: 'download.download_button_label_summary_chapters'
+})(({downloadPluginManager, shouldFocus, fileName, title, ariaLabel}: SummaryChaptersListProps) => {
   return (
     <div className={styles.summaryChaptersContainer}>
       <div className={styles.summaryChaptersLabel}>{title}</div>
@@ -30,7 +31,7 @@ export const SummaryChaptersList = withText({
         downloadUrl={''}
         assetType={assetType.SummaryAndChapters}
         iconFileType={<CommonIcon name="pdf" />}
-        ariaLabel={title!}
+        ariaLabel={ariaLabel}
         shouldFocus={shouldFocus}
       />
     </div>

--- a/src/components/summary-chapters-list/summary-chapters-list.tsx
+++ b/src/components/summary-chapters-list/summary-chapters-list.tsx
@@ -1,0 +1,38 @@
+import {h, ComponentChildren} from 'preact';
+import {DownloadPluginManager} from '../../download-plugin-manager';
+import {DownloadItem} from '../download-item';
+import * as styles from './summary-chapters-list.scss';
+import {assetType} from '../../consts/asset-type';
+import {AssetsListProps} from '../../types/assets-list-props';
+import {Icon as CommonIcon} from '@playkit-js/common/dist/icon';
+
+import {ui} from '@playkit-js/kaltura-player-js';
+
+const {withText} = ui.preacti18n;
+const {Icon} = ui.components;
+
+interface SummaryChaptersListProps extends AssetsListProps {
+  downloadPluginManager: DownloadPluginManager;
+  shouldFocus: boolean;
+  fileName: string;
+  title?: string;
+}
+
+export const SummaryChaptersList = withText({
+  title: 'download.summary_chapters_label'
+})(({downloadPluginManager, shouldFocus, fileName, title}: SummaryChaptersListProps) => {
+  return (
+    <div className={styles.summaryChaptersContainer}>
+      <div className={styles.summaryChaptersLabel}>{title}</div>
+      <DownloadItem
+        downloadPluginManager={downloadPluginManager}
+        fileName={`${fileName}.pdf`}
+        downloadUrl={''}
+        assetType={assetType.SummaryAndChapters}
+        iconFileType={<CommonIcon name="pdf" />}
+        ariaLabel={title!}
+        shouldFocus={shouldFocus}
+      />
+    </div>
+  );
+});

--- a/src/consts/asset-type.ts
+++ b/src/consts/asset-type.ts
@@ -1,5 +1,6 @@
 export enum assetType {
   Media = 'Media',
   Captions = 'Captions',
-  Attachments = 'Attachments'
+  Attachments = 'Attachments',
+  SummaryAndChapters = 'SummaryAndChapters'
 }

--- a/src/download-plugin-manager.tsx
+++ b/src/download-plugin-manager.tsx
@@ -13,6 +13,7 @@ const {FakeEvent} = core;
 
 class DownloadPluginManager extends core.FakeEventTarget {
   private _showOverlay = false;
+  private _showSummaryAndChapters = false;
   private downloadService: DownloadService;
   private downloadMetadatas: DownloadMetadata[] = [null];
   private playOnClose = false;
@@ -20,6 +21,14 @@ class DownloadPluginManager extends core.FakeEventTarget {
   constructor(public downloadPlugin: Download, private _config: DownloadConfig, private _logger: any, private _eventManager: core.EventManager) {
     super();
     this.downloadService = new DownloadService(this.downloadPlugin.player, this._logger, this._eventManager);
+  }
+
+  public get showSummaryAndChapters(): boolean {
+    return this._showSummaryAndChapters;
+  }
+
+  public set showSummaryAndChapters(value: boolean) {
+    this._showSummaryAndChapters = value;
   }
 
   get config(): DownloadConfig {

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -178,6 +178,9 @@ class Download extends BasePlugin {
     this.eventManager?.listen(this.downloadPluginManager, DownloadEvent.HIDE_OVERLAY, (e: FakeEvent) =>
       this.dispatchEvent(DownloadEvent.HIDE_OVERLAY, e.payload)
     );
+    this.eventManager.listen(this.player, 'unisphere.event.player.upper-bar-icon.show', () => {
+      this.downloadPluginManager.showSummaryAndChapters = true;
+    });
   }
 
   reset() {
@@ -187,6 +190,7 @@ class Download extends BasePlugin {
     this.audioPlayerIconId = -1;
     this._pluginButtonRef = null;
     this.triggeredByKeyboard = false;
+    this.downloadPluginManager.showSummaryAndChapters = false;
 
     for (const componentDisposer of this.componentDisposers) {
       componentDisposer();

--- a/src/event/download-event.d.ts
+++ b/src/event/download-event.d.ts
@@ -3,4 +3,5 @@ export namespace DownloadEvent {
   const DOWNLOAD_ITEM_CLICKED: string;
   const SHOW_OVERLAY: string;
   const HIDE_OVERLAY: string;
+  const DOWNLOAD_SUMMARY_AND_CHAPTERS_DOWNLOAD: string;
 }

--- a/src/event/download-event.js
+++ b/src/event/download-event.js
@@ -1,7 +1,8 @@
 const DownloadEvent = {
   DOWNLOAD_ITEM_CLICKED: 'download_item_clicked',
   SHOW_OVERLAY: 'download_show_overlay',
-  HIDE_OVERLAY: 'download_hide_overlay'
+  HIDE_OVERLAY: 'download_hide_overlay',
+  DOWNLOAD_SUMMARY_AND_CHAPTERS_DOWNLOAD: 'download_summary_chapters_download'
 };
 
 export {DownloadEvent};

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -15,6 +15,7 @@
       "more_captions_label": "More captions",
       "less_captions_label": "Less captions",
       "attachments_label": "Attachments",
+      "summary_chapters_label": "Summary & chapters",
       "main_stream": "Main stream",
       "additional_streams": "Additional streams",
       "captions": "Captions",

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -9,6 +9,7 @@
       "download_button_label_video": "Click to download the video",
       "download_button_label_captions": "Click to download the captions",
       "download_button_label_attachment": "Click to download the attachment",
+      "download_button_label_summary_chapters": "Click to download the summary and chapters",
       "select_quality_label": "Select quality",
       "hide_label": "Hide",
       "source_label": "Source",


### PR DESCRIPTION
### Description of the Changes

Adding summary & chapter section in the download plugin if summary & chapters plugin are enabled and loaded.
When clicking on the file event is triggered and so downloadAsPdf api is called in summary api.

related pr - https://github.com/kaltura/playkit-js-unisphere/pull/31, https://github.com/kaltura/unisphere-video-summary/pull/110

solves [CR-616](https://kaltura.atlassian.net/browse/CR-616)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[CR-616]: https://kaltura.atlassian.net/browse/CR-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ