### PR TITLE
fix(SUP-52205): V7 Audio player does not allow AIFF source download When WebM flavor is present

### DIFF
--- a/src/components/sources-list/sources-list.tsx
+++ b/src/components/sources-list/sources-list.tsx
@@ -160,8 +160,8 @@ export const SourcesList = withText({
           <ExpandableContainer
             defaultItem={_renderFlavor(defaultFlavor!, true)}
             restOfItems={_renderFlavors(flavors)}
-            showMoreLabel={selectQualityLabel!}
-            showLessLabel={hideLabel!}
+            showMoreLabel={selectQualityLabel || 'Select quality'}
+            showLessLabel={hideLabel || 'Hide'}
           />
         );
       }

--- a/src/providers/response-types/kaltura-flavor-asset-list-response.ts
+++ b/src/providers/response-types/kaltura-flavor-asset-list-response.ts
@@ -37,7 +37,7 @@ export class KalturaFlavorAssetListResponse extends BaseServiceResult {
     const updatedFlavors = flavors.map((flavor: any) => {
       return {
         ...flavor,
-        uniqKey: `${flavor.height}_${flavor.width}_${flavor.language}_${flavor.frameRate}`,
+        uniqKey: `${flavor.height}_${flavor.width}_${flavor.language}_${flavor.frameRate}_${flavor.fileExt}`,
         isAudio: flavor.height === 0 && flavor.width === 0 && flavor.frameRate === 0
       };
     });


### PR DESCRIPTION
Issue:
AIFF with WEBM source is not presented

root cause:
the unique key was not unique enough and it removes the AIFF flavors

Fix:
Handle the unique key by fileExec type and add hide&show Select quality buttons

solve [SUP-52205](https://kaltura.atlassian.net/browse/SUP-52435)

[SUP-52205]: https://kaltura.atlassian.net/browse/SUP-52205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ